### PR TITLE
Add variable to enable and support syslog

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ None
 * `cron_apt_mailto`: [default: `root`]: The email address to send mail to
 * `cron_apt_mailon`: [default: `upgrade`]: When to send email about the cron-apt results
 * `cron_apt_options`: [optional]: General apt options that will be passed to all `APTCOMMAND` calls
+* `cron_apt_syslogon`: [optional]: When to send the cron-apt results to syslog
+  (disabled by default with `false`)
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 ---
 cron_apt_mailto: root
 cron_apt_mailon: upgrade
+cron_apt_syslogon: false

--- a/templates/etc/cron-apt/config.j2
+++ b/templates/etc/cron-apt/config.j2
@@ -102,7 +102,11 @@ MAILON="{{ cron_apt_mailon }}"
 #	 output  (syslog when output is generated)
 #        always  (always syslog)
 #                (else never syslog)
+{% if cron_apt_syslogon %}
+SYSLOGON="{{ cron_apt_syslogon }}"
+{% else %}
 # SYSLOGON="upgrade"
+{% endif %}
 
 # Value: error   (exit on error only)
 #                (else never exit)


### PR DESCRIPTION
Hi!

We needed this feature, so we thought it was interesting to share it. I used the `none` value to disable this feature (so that there is no change by default), and other possible values are the same as for `cron_apt_mailon`.

Cheers,
William